### PR TITLE
Strings and Boxed types should be compared using "equals()"

### DIFF
--- a/src/main/java/org/apache/sling/discovery/impl/cluster/voting/VotingView.java
+++ b/src/main/java/org/apache/sling/discovery/impl/cluster/voting/VotingView.java
@@ -388,7 +388,7 @@ public class VotingView extends View {
                         }
                     } else if (v instanceof Boolean) {
                         Boolean b = (Boolean)v;
-                        if (b == vote) {
+                        if (b.equals(vote)) {
                             logger.debug("vote: already voted, with same vote ("+vote+"), not voting again");
                             shouldVote = false;
                         }


### PR DESCRIPTION
This fixes 1 Sonarqube violation of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973

Sonarcloud violation URL:
https://sonarcloud.io/organizations/apache/issues?open=AWpM6AUjyRjJygCrlORM&resolved=false&rules=squid%3AS4973

Jira ticket:
https://issues.apache.org/jira/browse/SLING-8825