### PR TITLE
SLING-12419: Snapshot dependencies in discovery.impl

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,0 +1,5 @@
+{
+  "jenkins": {
+    "sonarQubeEnabled": false
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,15 @@
                 </executions>
             </plugin>
             <!-- END workarounds for Java 11+ -->
+            <!--
+                Use recent maven-bundle-plugin for Java 21 build on Windows.
+                Can be removed after upgrading to a recent Sling parent pom.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.discovery.commons</artifactId>
-			<version>1.0.21-SNAPSHOT</version>
+			<version>1.0.28</version>
             <scope>provided</scope>
 		</dependency>
         <!-- besides including discovery.commons' normal jar above, 
@@ -167,14 +167,14 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.discovery.commons</artifactId>
-            <version>1.0.21-SNAPSHOT</version>
+            <version>1.0.28</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
 		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.discovery.base</artifactId>
-			<version>2.0.1-SNAPSHOT</version>
+			<version>2.0.14</version>
             <scope>provided</scope>
 		</dependency>
         <!-- besides including discovery.base' normal jar above, 
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.discovery.base</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.14</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -202,7 +202,7 @@
         <dependency>
         	<groupId>org.apache.sling</groupId>
         	<artifactId>org.apache.sling.commons.scheduler</artifactId>
-        	<version>2.3.4</version>
+        	<version>2.5.2</version>
             <scope>provided</scope>
         </dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                       on AEM 5.6.1 - thus switching back to 2.5.3 here:
 					javax.servlet,version=[2.6,3) - - Cannot be resolved
 					javax.servlet.http,version=[2.6,3) - - Cannot be resolved
-                       -->
+                -->
                 <version>2.5.3</version>
                 <extensions>true</extensions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,35 @@
     </scm>
 
     <properties>
-      <jackrabbit.version>2.12.2</jackrabbit.version>
+      <jackrabbit.version>2.14.3</jackrabbit.version>
         <!-- by default Slow tests are excluded - use -PincludeSlowTests to include them -->
         <sling.excluded.surefire.groups>org.apache.sling.commons.testing.junit.categories.Slow</sling.excluded.surefire.groups>
+        <!--
+            Explicitly set bundle required execution environment and
+            disable set-bundle-required-execution-environment execution
+            of maven-antrun-plugin. Allows building with Java 11.
+            Can be removed after upgrading to a recent Sling parent pom.
+            See also SLING-12419.
+        -->
+        <sling.java.version>8</sling.java.version>
+        <sling.bree>JavaSE-1.8</sling.bree>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <sling.animalSignatures.version>6</sling.animalSignatures.version>
     </properties>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- disable and explicitly set properties (SLING-12419) -->
+                        <id>set-bundle-required-execution-environment</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-surefire-plugin</artifactId>
@@ -278,7 +300,23 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+        <!--
+            Use the following two Jackrabbit modules at 2.14.3
+            or higher to make build work on Java 9+ (JCR-4179)
+        -->
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+            <version>${jackrabbit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-spi-commons</artifactId>
+            <version>${jackrabbit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- using log4j under slf4j to allow fine-grained logging config (see src/test/resources/log4j.properties) -->
         <dependency>
         	<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-      <jackrabbit.version>2.14.3</jackrabbit.version>
+      <jackrabbit.version>2.20.16</jackrabbit.version>
         <!-- by default Slow tests are excluded - use -PincludeSlowTests to include them -->
         <sling.excluded.surefire.groups>org.apache.sling.commons.testing.junit.categories.Slow</sling.excluded.surefire.groups>
         <!--
@@ -59,6 +59,11 @@
 
     <build>
         <plugins>
+            <!--
+                START workarounds for Java 11+
+                Can be removed after upgrading to a recent Sling parent pom.
+                See also SLING-12419.
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -70,6 +75,37 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                ianal-maven-plugin does not work with Java 11+,
+                but tools-maven-plugin does.
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>ianal-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.geronimo.genesis.plugins</groupId>
+                <artifactId>tools-maven-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>verify-legal-files</id>
+                        <goals>
+                            <goal>verify-legal-files</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Fail the build if any artifacts are missing legal files -->
+                            <strict>true</strict>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- END workarounds for Java 11+ -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-surefire-plugin</artifactId>
@@ -155,8 +191,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.jackrabbit</groupId>
-			<artifactId>jackrabbit-api</artifactId>
-			<version>${jackrabbit.version}</version>
+			<artifactId>oak-jackrabbit-api</artifactId>
+			<version>1.48.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -301,8 +337,9 @@
             </exclusions>
         </dependency>
         <!--
-            Use the following two Jackrabbit modules at 2.14.3
-            or higher to make build work on Java 9+ (JCR-4179)
+            Use the following Jackrabbit modules at 2.20.16
+            or higher to make build work on Java 9+.
+            See JCR-4179 and JCR-4278.
         -->
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
@@ -314,6 +351,19 @@
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-spi-commons</artifactId>
             <version>${jackrabbit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-core</artifactId>
+            <version>${jackrabbit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Tests use persistence on derby -->
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.14.2.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/org/apache/sling/discovery/impl/common/heartbeat/HeartbeatTest.java
+++ b/src/test/java/org/apache/sling/discovery/impl/common/heartbeat/HeartbeatTest.java
@@ -32,8 +32,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import javax.jcr.Property;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.RootLogger;
 import org.apache.sling.api.resource.ModifiableValueMap;
@@ -684,13 +682,13 @@ public class HeartbeatTest {
                 assertTrue(ongoingVote.hasVotedYes(slowMachine2.getSlingId()));
                 final Resource memberResource = ongoingVote.getResource().getChild("members").getChild(slowMachine2.getSlingId());
                 final ModifiableValueMap memberMap = memberResource.adaptTo(ModifiableValueMap.class);
-                Property vote = (Property) memberMap.get("vote");
-                assertEquals(Boolean.TRUE, vote.getBoolean());
-                Property votedAt = (Property) memberMap.get("votedAt");
+                Boolean vote = (Boolean) memberMap.get("vote");
+                assertEquals(Boolean.TRUE, vote);
+                Calendar votedAt = (Calendar) memberMap.get("votedAt");
                 if (previousVotedAt==null) {
-                    previousVotedAt = votedAt.getDate();
+                    previousVotedAt = votedAt;
                 } else {
-                    assertEquals(previousVotedAt, votedAt.getDate());
+                    assertEquals(previousVotedAt, votedAt);
                 }
             } catch(Exception e) {
                 resourceResolver.close();


### PR DESCRIPTION
Update to released versions of discovery.base and discovery.commons.
Update commons.scheduler dependency required by discovery.base.
Fix HeartbeatTest after dependency updates.