### PR TITLE
SLING-12458: Migrate discovery.impl to Resource Observation API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,11 +93,6 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.event</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -171,7 +166,7 @@
 		<dependency>
 			<groupId>org.apache.sling</groupId>
 			<artifactId>org.apache.sling.api</artifactId>
-			<version>2.7.0</version>
+			<version>2.11.0</version>
             <scope>provided</scope>
 		</dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -296,5 +296,11 @@
             <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                    <argLine>-Xmx2048m</argLine>
+                    <argLine>-Xmx2048m ${jacoco.ut.command}</argLine>
                     <excludedGroups>${sling.excluded.surefire.groups}</excludedGroups>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <jackrabbit.version>2.20.16</jackrabbit.version>
         <!-- by default Slow tests are excluded - use -PincludeSlowTests to include them -->
         <sling.excluded.surefire.groups>org.apache.sling.commons.testing.junit.categories.Slow</sling.excluded.surefire.groups>
+        <surefireMemory>-Xmx2048m</surefireMemory>
+        <surefireArgLine>${surefireMemory}</surefireArgLine>
     </properties>
 
     <build>
@@ -52,7 +54,7 @@
                  <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
-                    <argLine>-Xmx2048m ${jacoco.ut.command}</argLine>
+                    <argLine>${surefireArgLine}</argLine>
                     <excludedGroups>${sling.excluded.surefire.groups}</excludedGroups>
                 </configuration>
             </plugin>
@@ -66,6 +68,12 @@
             <id>includeSlowTests</id>
             <properties>
                 <sling.excluded.surefire.groups />
+            </properties>
+        </profile>
+        <profile>
+            <id>jacoco-report</id>
+            <properties>
+                <surefireArgLine>${surefireMemory} ${jacoco.ut.command}</surefireArgLine>
             </properties>
         </profile>
     </profiles>

--- a/src/main/java/org/apache/sling/discovery/impl/cluster/ClusterViewChangeListener.java
+++ b/src/main/java/org/apache/sling/discovery/impl/cluster/ClusterViewChangeListener.java
@@ -149,12 +149,11 @@ public class ClusterViewChangeListener {
                 handleTopologyChanged();
             }
         }
-    }
 
-    /** Inform the DiscoveryServiceImpl that the topology (might) have changed **/
-    private void handleTopologyChanged() {
-        logger.debug("handleTopologyChanged: detected a change in the established views, invoking checkForTopologyChange.");
-        discoveryService.checkForTopologyChange();
+        /** Inform the DiscoveryServiceImpl that the topology (might) have changed **/
+        private void handleTopologyChanged() {
+            logger.debug("handleTopologyChanged: detected a change in the established views, invoking checkForTopologyChange.");
+            discoveryService.checkForTopologyChange();
+        }
     }
-
 }

--- a/src/test/java/org/apache/sling/discovery/impl/cluster/ClusterViewChangeListenerTest.java
+++ b/src/test/java/org/apache/sling/discovery/impl/cluster/ClusterViewChangeListenerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.discovery.impl.cluster;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.api.resource.observation.ResourceChange;
+import org.apache.sling.api.resource.observation.ResourceChangeListener;
+import org.apache.sling.discovery.commons.providers.spi.base.DummySlingSettingsService;
+import org.apache.sling.discovery.impl.Config;
+import org.apache.sling.discovery.impl.DiscoveryServiceImpl;
+import org.apache.sling.settings.SlingSettingsService;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.apache.sling.testing.resourceresolver.MockResourceResolverFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ClusterViewChangeListenerTest {
+
+    private final OsgiContext context = new OsgiContext();
+
+    private final Config config = new Config();
+    private final ResourceResolverFactory resolverFactory = new MockResourceResolverFactory();
+    private final SlingSettingsService settingsService = new DummySlingSettingsService("1", "target");
+    private final MockDiscoveryServiceImpl discoveryService = new MockDiscoveryServiceImpl();
+    private final ClusterViewChangeListener clusterViewChangeListener = new ClusterViewChangeListener();
+
+    @Before
+    public void setup() {
+        context.registerInjectActivateService(config);
+        context.registerService(ResourceResolverFactory.class, resolverFactory);
+        context.registerService(SlingSettingsService.class, settingsService);
+        context.registerService(DiscoveryServiceImpl.class, discoveryService);
+        context.registerInjectActivateService(clusterViewChangeListener);
+    }
+
+    @After
+    public void tearDown() {
+        clusterViewChangeListener.deactivate();
+    }
+
+    @Test
+    public void resourceChangeListenerRegistered() {
+        ResourceChangeListener listener = context.getService(ResourceChangeListener.class);
+        assertNotNull(listener);
+    }
+
+    @Test
+    public void changeUnrelatedResource() {
+        change("/unrelated");
+        assertEquals(0, discoveryService.getCheckForTopologyChangeCount());
+    }
+
+    @Test
+    public void changeResourceUnderEstablishedView() {
+        change(config.getEstablishedViewPath() + "/foo");
+        assertEquals(1, discoveryService.getCheckForTopologyChangeCount());
+    }
+
+    @Test
+    public void changeResourceUnderClusterInstancePath() {
+        change(config.getClusterInstancesPath() + "/foo");
+        assertEquals(1, discoveryService.getCheckForTopologyChangeCount());
+    }
+
+    @Test
+    public void changeResourceUnderClusterInstancePathWithPropertyChange() {
+        change(config.getClusterInstancesPath() + "/foo", "some-property");
+        assertEquals(1, discoveryService.getCheckForTopologyChangeCount());
+    }
+
+    @Test
+    public void ignoreHeartbeat() {
+        change(config.getClusterInstancesPath() + "/foo", "lastHeartbeat");
+        assertEquals(0, discoveryService.getCheckForTopologyChangeCount());
+    }
+
+    private void change(String path, String changedProperty) {
+        deliver(changed(path, changedProperty));
+    }
+
+    private void change(String path) {
+        deliver(changed(path));
+    }
+
+    private void deliver(ResourceChange change) {
+        List<ResourceChange> changes = Collections.singletonList(change);
+        Arrays.asList(context.getServices(ResourceChangeListener.class, null))
+                .forEach(listener -> listener.onChange(changes));
+    }
+
+    public static class MockDiscoveryServiceImpl extends DiscoveryServiceImpl {
+
+        private final AtomicInteger checkForTopologyChangeCounter = new AtomicInteger(0);
+
+        int getCheckForTopologyChangeCount() {
+            return checkForTopologyChangeCounter.get();
+        }
+
+        @Override
+        public void checkForTopologyChange() {
+            checkForTopologyChangeCounter.incrementAndGet();
+            super.checkForTopologyChange();
+        }
+    }
+
+    private static ResourceChange changed(String path) {
+        return new ResourceChange(ResourceChange.ChangeType.CHANGED, path, false, null, null, null);
+    }
+
+    private static ResourceChange changed(String path, String changedProperty) {
+        return new ResourceChange(ResourceChange.ChangeType.CHANGED, path, false, null, Collections.singleton(changedProperty), null);
+    }
+}

--- a/src/test/java/org/apache/sling/discovery/impl/setup/VotingEventListener.java
+++ b/src/test/java/org/apache/sling/discovery/impl/setup/VotingEventListener.java
@@ -56,7 +56,7 @@ class VotingEventListener implements EventListener {
                         Thread.sleep(10);
                         continue;
                     }
-                    logger.debug("async.run: delivering event to listener: "+slingId+", stopped: "+stopped+", change: "+c);
+                    logger.debug(String.format("async.run: delivering event to listener: %s, stopped: %s, change: %s", slingId, stopped, c));
                     votingHandler.onChange(Collections.singletonList(c));
                 } catch(Exception e) {
                     logger.error("async.run: got Exception: "+e, e);
@@ -93,7 +93,7 @@ class VotingEventListener implements EventListener {
                 }
                 try {
                     ResourceChange c = new ResourceChange(type, event.getPath(), false, null, null, null);
-                    logger.debug("onEvent: enqueuing event to listener: "+slingId+", stopped: "+stopped+", change: "+c);
+                    logger.debug(String.format("onEvent: enqueuing event to listener: %s, stopped: %s, change: %s", slingId, stopped, c));
                     q.add(c);
                 } catch (RepositoryException e) {
                     logger.warn("RepositoryException: " + e, e);


### PR DESCRIPTION
Replace usage of OSGi events with Resource Observation API
Update Sling API to 2.11.0, which introduced the Resource Observation API
Remove now obsolete org.osgi.service.event dependency